### PR TITLE
Update default properties file, making it ready for main net launch

### DIFF
--- a/conf/nxt-default.properties
+++ b/conf/nxt-default.properties
@@ -68,7 +68,7 @@ nxt.myHallmark=
 
 # Default initial peers. Only used if nxt.usePeersDb=true.
 # Do not modify. Add custom peers to nxt.wellKnownPeers instead.
-nxt.defaultPeers=
+nxt.defaultPeers=mainnet-server1.ryacoin.io;mainnet-server2.ryacoin.io;mainnet-server3.ryacoin.io;mainnet-server4.ryacoin.io;mainnet-server5.ryacoin.io;mainnet-server6.ryacoin.io;
 
 # A list of well known peer addresses / host names, separated by '; '. These
 # peers are always kept in connected state.
@@ -79,7 +79,7 @@ nxt.knownBlacklistedPeers=
 
 # Default initial peers used for testnet only. Only used if nxt.usePeersDb=true.
 # Do not modify. Add custom testnet peers to nxt.testnetPeers instead.
-nxt.defaultTestnetPeers=testnet-server2.ryacoin.io;testnet-server3.ryacoin.io;testnet-server4.ryacoin.io;testnet-server5.ryacoin.io;testnet-server6.ryacoin.io;testnet-server7.ryacoin.io;
+nxt.defaultTestnetPeers=testnet-server2.ryacoin.io;testnet-server3.ryacoin.io;testnet-server4.ryacoin.io;
 
 # Well known testnet peers.
 nxt.testnetPeers=
@@ -144,7 +144,7 @@ nxt.enablePeerServerGZIPFilter=true
 # When using testnet, all custom port settings will be ignored,
 # and hardcoded ports of 8874 (peer networking), 8875 (UI) and 8876 (API) will
 # be used.
-nxt.isTestnet=true
+nxt.isTestnet=false
 
 # Save known peers in the database
 nxt.savePeers=true
@@ -184,8 +184,8 @@ nxt.enableAPIServer=true
 
 # Hosts from which to allow http/json API requests, if enabled. Set to * to
 # allow all. Can also specify networks in CIDR notation, e.g. 192.168.1.0/24.
-#nxt.allowedBotHosts=127.0.0.1; localhost; [0:0:0:0:0:0:0:1];
-nxt.allowedBotHosts=*
+nxt.allowedBotHosts=127.0.0.1; localhost; [0:0:0:0:0:0:0:1];
+#nxt.allowedBotHosts=*
 
 # Port for http/json API requests.
 nxt.apiServerPort=7876


### PR DESCRIPTION
- added default peers as main-net servers
- removed a few test-net servers
- isTested set to false
- allow API requests from local host only