### PR TITLE
Hide "Outdated" message on client

### DIFF
--- a/html/www/js/nrs.update.js
+++ b/html/www/js/nrs.update.js
@@ -21,14 +21,14 @@ var NRS = (function(NRS, $) {
 	var DOWNLOAD_REPOSITORY_URL = "https://bitbucket.org/Jelurida/nxt/downloads/";
 	var index = 0;
 	var bundles = [
-		{alias: "nrsVersion", status: "release", prefix: "nxt-client-", ext: "zip"},
+		/*{alias: "nrsVersion", status: "release", prefix: "nxt-client-", ext: "zip"},
 		{alias: "nrsBetaVersion", status: "beta", prefix: "nxt-client-", ext: "zip"},
 		{alias: "nrsVersionWin", status: "release", prefix: "nxt-client-", ext: "exe"},
 		{alias: "nrsBetaVersionWin", status: "beta", prefix: "nxt-client-", ext: "exe"},
 		{alias: "nrsVersionMac", status: "release", prefix: "nxt-installer-", ext: "dmg"},
 		{alias: "nrsBetaVersionMac", status: "beta", prefix: "nxt-installer-", ext: "dmg"},
 		{alias: "nrsVersionLinux", status: "release", prefix: "nxt-client-", ext: "sh"},
-		{alias: "nrsBetaVersionLinux", status: "beta", prefix: "nxt-client-", ext: "sh"}
+		{alias: "nrsBetaVersionLinux", status: "beta", prefix: "nxt-client-", ext: "sh”}*/
 	];
 	NRS.isOutdated = false;
 


### PR DESCRIPTION
The "Outdated" message appears due to that the client tries to find the version number in a bundle of clients available in a hard-coded repository URL. The list and URL are currently NXT dependent, which is why the outdated message appears for Rya client.

Commented out the list of NXT bundles for now. To be updated with Rya bundles and Repo URL in the future.